### PR TITLE
change StringFilter::getOperator to protected

### DIFF
--- a/Filter/StringFilter.php
+++ b/Filter/StringFilter.php
@@ -55,7 +55,7 @@ class StringFilter extends Filter
      *
      * @return bool
      */
-    private function getOperator($type)
+    protected function getOperator($type)
     {
         $choices = array(
             ChoiceType::TYPE_CONTAINS         => 'LIKE',


### PR DESCRIPTION
in order to be able to override getOperator() without changing the filter method
